### PR TITLE
Update timetable router with last-week and next-week

### DIFF
--- a/server/routes/timetable/index.ts
+++ b/server/routes/timetable/index.ts
@@ -1,5 +1,5 @@
 import { type RequestHandler, Router } from 'express'
-import { format, addDays, subDays } from 'date-fns'
+import { addDays, subDays } from 'date-fns'
 
 import asyncMiddleware from '../../middleware/asyncMiddleware'
 import type { Services } from '../../services'

--- a/server/routes/timetable/index.ts
+++ b/server/routes/timetable/index.ts
@@ -1,5 +1,5 @@
 import { type RequestHandler, Router } from 'express'
-import { addDays } from 'date-fns'
+import { format, addDays, subDays } from 'date-fns'
 
 import asyncMiddleware from '../../middleware/asyncMiddleware'
 import type { Services } from '../../services'
@@ -33,12 +33,54 @@ export default function routes(services: Services): Router {
     })
   })
 
-  get('/last-week', (req, res) => {
-    return res.json({ last: 'week' })
+  get('/last-week', async (req, res) => {
+    const config = {
+      content: false,
+      header: false,
+      postscript: true,
+      detailsType: 'small',
+      lastWeek: true,
+      nextWeek: false,
+    }
+
+    const today = new Date()
+    const fromDate = subDays(today, 7)
+    const toDate = subDays(today, 1)
+
+    const events = await Promise.all([services.prisonerProfileService.getEventsFor(res.locals.user, fromDate, toDate)])
+
+    return res.render('pages/timetable', {
+      title: 'Timetable',
+      config,
+      events,
+      errors: req.flash('errors'),
+      message: req.flash('message'),
+    })
   })
 
-  get('/next-week', (req, res) => {
-    return res.json({ next: 'week' })
+  get('/next-week', async (req, res) => {
+    const config = {
+      content: false,
+      header: false,
+      postscript: true,
+      detailsType: 'small',
+      lastWeek: false,
+      nextWeek: true,
+    }
+
+    const today = new Date()
+    const fromDate = addDays(today, 7)
+    const toDate = addDays(fromDate, 6)
+
+    const events = await Promise.all([services.prisonerProfileService.getEventsFor(res.locals.user, fromDate, toDate)])
+
+    return res.render('pages/timetable', {
+      title: 'Timetable',
+      config,
+      events,
+      errors: req.flash('errors'),
+      message: req.flash('message'),
+    })
   })
 
   return router


### PR DESCRIPTION
**Related to the following ticket:**
- https://dsdmoj.atlassian.net/browse/LNP-499

**Changes made in this ticket:**
- Updated the timetable router to include last-week and next week functionality.

**Screen shots:**
![localhost_3000_timetable_last-week](https://github.com/ministryofjustice/hmpps-launchpad-home-ui/assets/104000682/c4fdfecb-b746-4eac-a25f-2b19092bf9ee)
![localhost_3000_timetable_next-week](https://github.com/ministryofjustice/hmpps-launchpad-home-ui/assets/104000682/a2b3a022-2180-4b4f-bef6-224fa54bbc9d)
