### PR TITLE
LNP-123: Add GA4 code block

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,6 +108,9 @@ dist
 # Stores VSCode versions used for testing VSCode extensions
 .vscode-test
 
+# Ignore mac file
+.DS_Store
+
 # yarn v2
 .yarn/cache
 .yarn/unplugged

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -16,6 +16,7 @@ generic-service:
     INCENTIVES_API_URL: "https://incentives-api-dev.hmpps.service.justice.gov.uk"
     PRISONER_CONTACT_REGISTRY_API_URL: "https://prisoner-contact-registry-dev.prison.service.justice.gov.uk"
     LAUNCHPAD_AUTH_URL: "https://launchpad-auth-dev.hmpps.service.justice.gov.uk"
+    GA4_SITE_ID: "G-EJVJ26SLFY"
 
   allowlist:
     bsi-1: 54.37.241.156/30

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -16,6 +16,7 @@ generic-service:
     INCENTIVES_API_URL: "https://incentives-api-preprod.hmpps.service.justice.gov.uk"
     PRISONER_CONTACT_REGISTRY_API_URL: "https://prisoner-contact-registry-preprod.prison.service.justice.gov.uk"
     LAUNCHPAD_AUTH_URL: "https://launchpad-auth-preprod.hmpps.service.justice.gov.uk"
+    GA4_SITE_ID: "G-4VW039LBEF"
 
 generic-prometheus-alerts:
   alertSeverity: digital-prison-service-dev

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -16,6 +16,7 @@ generic-service:
     INCENTIVES_API_URL: "https://incentives.hmpps.service.justice.gov.uk"
     PRISONER_CONTACT_REGISTRY_API_URL: "https://prisoner-contact-registry.prison.service.justice.gov.uk"
     LAUNCHPAD_AUTH_URL: "https://launchpad-auth.hmpps.service.justice.gov.uk"
+    GA4_SITE_ID: "G-7M5BW140G4"
 
   allowlist:
     groups:

--- a/helm_deploy/values-staging.yaml
+++ b/helm_deploy/values-staging.yaml
@@ -17,6 +17,7 @@ generic-service:
     PRISONER_CONTACT_REGISTRY_API_URL: "https://prisoner-contact-registry-dev.prison.service.justice.gov.uk"
     LAUNCHPAD_AUTH_URL: "https://launchpad-auth-dev.hmpps.service.justice.gov.uk"
     APPLICATIONINSIGHTS_CONNECTION_STRING: null
+    GA4_SITE_ID: "G-4VW039LBEF"
 
   namespace_secrets:
     hmpps-launchpad-home-ui:

--- a/server/config.ts
+++ b/server/config.ts
@@ -223,6 +223,6 @@ export default {
   ],
   analytics: {
     // use staging GA4 tag as fallback
-    siteId: get('GA4_SITE_ID', 'G-4VW039LBEF', requiredInProduction),
+    ga4SiteId: get('GA4_SITE_ID', 'G-4VW039LBEF', requiredInProduction),
   },
 }

--- a/server/config.ts
+++ b/server/config.ts
@@ -221,4 +221,8 @@ export default {
       selfServiceURL: 'https://wyiclient.unilink.prisoner.service.justice.gov.uk:1100',
     },
   ],
+  analytics: {
+    // use staging GA4 tag as fallback
+    siteId: get('GA4_SITE_ID', 'G-4VW039LBEF', requiredInProduction),
+  },
 }

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -38,6 +38,6 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
       express: app,
     },
   )
-  njkEnv.addGlobal('GA4_SITE_ID', config.analytics.siteId)
+  njkEnv.addGlobal('ga4SiteId', config.analytics.ga4SiteId)
   njkEnv.addFilter('initialiseName', initialiseName)
 }

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -3,6 +3,7 @@ import * as pathModule from 'path'
 import nunjucks from 'nunjucks'
 import express from 'express'
 import { initialiseName } from './utils'
+import config from '../config'
 
 const production = process.env.NODE_ENV === 'production'
 
@@ -37,6 +38,6 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
       express: app,
     },
   )
-
+  njkEnv.addGlobal('GA4_SITE_ID', config.analytics.siteId)
   njkEnv.addFilter('initialiseName', initialiseName)
 }

--- a/server/views/partials/template.njk
+++ b/server/views/partials/template.njk
@@ -29,12 +29,12 @@
     {% endif %}
 
     <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id={{GA4_SITE_ID}}"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id={{ GA4_SITE_ID }}"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-      gtag('config', '{{GA4_SITE_ID}}');
+      gtag('config', '{{ GA4_SITE_ID }}');
    </script>  
 
   </head>

--- a/server/views/partials/template.njk
+++ b/server/views/partials/template.njk
@@ -29,12 +29,12 @@
     {% endif %}
 
     <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id={{ GA4_SITE_ID }}"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id={{ ga4SiteId }}"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-      gtag('config', '{{ GA4_SITE_ID }}');
+      gtag('config', '{{ ga4SiteId }}');
    </script>  
 
   </head>

--- a/server/views/partials/template.njk
+++ b/server/views/partials/template.njk
@@ -27,6 +27,16 @@
     {% if opengraphImageUrl or assetUrl %}
     <meta property="og:image" content="{{ opengraphImageUrl | default(assetUrl + '/images/govuk-opengraph-image.png') }}">
     {% endif %}
+
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id={{GA4_SITE_ID}}"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', '{{GA4_SITE_ID}}');
+   </script>  
+
   </head>
   <body class="govuk-template__body {{ bodyClasses }}" {%- for attribute, value in bodyAttributes %} {{attribute}}="{{value}}"{% endfor %}>
     <script{% if cspNonce %} nonce="{{ cspNonce }}"{% endif %}>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>


### PR DESCRIPTION
Added 
 - GA measurement ID inside helm_deploy folder for each environment
 - measurement ID as global configuration to be made available on all nunjucks template
 - Analytics JS snippet  added into the HTML
 - _.DS_Store_ to _.gitignore_ to exclude macOS files from version control
