### PR TITLE
Added Content Security Policy directives for GA4

### DIFF
--- a/server/middleware/setUpWebSecurity.ts
+++ b/server/middleware/setUpWebSecurity.ts
@@ -23,9 +23,20 @@ export default function setUpWebSecurity(): Router {
           // <link href="http://example.com/" rel="stylesheet" nonce="{{ cspNonce }}">
           // This ensures only scripts we trust are loaded, and not anything injected into the
           // page by an attacker.
-          scriptSrc: ["'self'", (_req: Request, res: Response) => `'nonce-${res.locals.cspNonce}'`],
+          scriptSrc: [
+            "'self'",
+            (_req: Request, res: Response) => `'nonce-${res.locals.cspNonce}'`,
+            'https://*.googletagmanager.com',
+          ],
           styleSrc: ["'self'", (_req: Request, res: Response) => `'nonce-${res.locals.cspNonce}'`],
           fontSrc: ["'self'"],
+          imgSrc: ["'self'", 'https://*.googletagmanager.com', 'https://*.google-analytics.com'],
+          connectSrc: [
+            "'self'",
+            'https://*.googletagmanager.com',
+            'https://*.google-analytics.com',
+            'https://*.analytics.google.com',
+          ],
         },
       },
       crossOriginEmbedderPolicy: true,

--- a/server/views/partials/template.njk
+++ b/server/views/partials/template.njk
@@ -30,12 +30,12 @@
 
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id={{ ga4SiteId }}"></script>
-    <script>
+    <script {% if cspNonce %} nonce="{{ cspNonce }}"{% endif %}>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
       gtag('config', '{{ ga4SiteId }}');
-   </script>  
+    </script>  
 
   </head>
   <body class="govuk-template__body {{ bodyClasses }}" {%- for attribute, value in bodyAttributes %} {{attribute}}="{{value}}"{% endfor %}>


### PR DESCRIPTION
Added the following Content Security Policy directives for GA4.
_script-src
img-src
connect-src_ as per the doc https://developers.google.com/tag-platform/security/guides/csp#google_analytics_4_google_analytics

Also added nonce to execute inline script.
