### PR TITLE
LNP-735-Adding-govuk-frontend-supported-class

### DIFF
--- a/server/views/partials/template.njk
+++ b/server/views/partials/template.njk
@@ -39,7 +39,7 @@
 
   </head>
   <body class="govuk-template__body {{ bodyClasses }}" {%- for attribute, value in bodyAttributes %} {{attribute}}="{{value}}"{% endfor %}>
-    <script{% if cspNonce %} nonce="{{ cspNonce }}"{% endif %}>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
+    <script{% if cspNonce %} nonce="{{ cspNonce }}"{% endif %}>document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');</script>
     {% block bodyStart %}{% endblock %}
 
     {% block skipLink %}


### PR DESCRIPTION
[LNP-735](https://dsdmoj.atlassian.net/browse/LNP-735)

Page templates now include a new `govuk-frontend-supported` class on the `<body>` tag when GOV.UK Frontend JavaScript components are fully supported.
https://github.com/alphagov/govuk-frontend/discussions/4389
https://github.com/alphagov/govuk-frontend/pull/4492

Update the <script> snippet at the top of your <body> tag
If you are not using our [Nunjucks page template](https://design-system.service.gov.uk/styles/page-template/), replace the existing snippet:

`<script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>`

with:

`<script>document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');</script>`

https://design-system.service.gov.uk/styles/page-template/

[LNP-735]: https://dsdmoj.atlassian.net/browse/LNP-735?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ