### PR TITLE
LNP-494-LP-berwyn-homepage

### DIFF
--- a/server/config.ts
+++ b/server/config.ts
@@ -139,7 +139,7 @@ export default {
       agencyId: 'BWI',
       prisonerContentHubURL: 'https://berwyn.content-hub.prisoner.service.justice.gov.uk',
       selfServiceURL: 'https://bwiclient.unilink.prisoner.service.justice.gov.uk:1108',
-      disableSectionEventsAndProfile: true,
+      hideHomepageEventsSummaryAndProfileLinkTile: true,
     },
     {
       agencyId: 'CKI',

--- a/server/config.ts
+++ b/server/config.ts
@@ -139,6 +139,7 @@ export default {
       agencyId: 'BWI',
       prisonerContentHubURL: 'https://berwyn.content-hub.prisoner.service.justice.gov.uk',
       selfServiceURL: 'https://bwiclient.unilink.prisoner.service.justice.gov.uk:1108',
+      disableSectionEventsAndProfile: true,
     },
     {
       agencyId: 'CKI',

--- a/server/routes/homepage/index.ts
+++ b/server/routes/homepage/index.ts
@@ -14,14 +14,17 @@ export default function routes(services: Services): Router {
     const { user } = res.locals
     const eventsData = await services.prisonerProfileService.getPrisonerEventsSummary(user)
     const linksData = await services.linksService.getHomepageLinks(user)
-    const establishmentLinksData = getEstablishmentLinksData(user.idToken.establishment.agency_id)
+    const establishmentLinksData = getEstablishmentLinksData(user.idToken?.establishment?.agency_id)
+    const hideHomepageEventsSummaryAndProfileLinkTile = establishmentLinksData
+      ? establishmentLinksData.hideHomepageEventsSummaryAndProfileLinkTile
+      : false
     return res.render('pages/homepage', {
       errors: req.flash('errors'),
       message: req.flash('message'),
       today: formatDate(new Date(), DateFormats.PRETTY_DATE),
       eventsData,
       linksData,
-      establishmentLinksData,
+      hideHomepageEventsSummaryAndProfileLinkTile,
     })
   })
 

--- a/server/routes/homepage/index.ts
+++ b/server/routes/homepage/index.ts
@@ -4,7 +4,7 @@ import { DateFormats } from '../../utils/enums'
 import asyncMiddleware from '../../middleware/asyncMiddleware'
 
 import type { Services } from '../../services'
-import { formatDate } from '../../utils/utils'
+import { formatDate, getEstablishmentLinksData } from '../../utils/utils'
 
 export default function routes(services: Services): Router {
   const router = Router()
@@ -14,13 +14,14 @@ export default function routes(services: Services): Router {
     const { user } = res.locals
     const eventsData = await services.prisonerProfileService.getPrisonerEventsSummary(user)
     const linksData = await services.linksService.getHomepageLinks(user)
-
+    const establishmentLinksData = getEstablishmentLinksData(user.idToken.establishment.agency_id)
     return res.render('pages/homepage', {
       errors: req.flash('errors'),
       message: req.flash('message'),
       today: formatDate(new Date(), DateFormats.PRETTY_DATE),
       eventsData,
       linksData,
+      establishmentLinksData,
     })
   })
 

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -44,11 +44,11 @@ export const generateBasicAuthHeader = (clientId: string, clientSecret: string):
 
 export const getEstablishmentLinksData = (agencyId: string) => {
   try {
-    const { prisonerContentHubURL, selfServiceURL } = config.establishments.find(
+    const { prisonerContentHubURL, selfServiceURL, disableSectionEventsAndProfile } = config.establishments.find(
       establishment => establishment.agencyId === agencyId,
     )
 
-    return { prisonerContentHubURL, selfServiceURL }
+    return { prisonerContentHubURL, selfServiceURL, disableSectionEventsAndProfile }
   } catch (err) {
     return null
   }

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -44,11 +44,10 @@ export const generateBasicAuthHeader = (clientId: string, clientSecret: string):
 
 export const getEstablishmentLinksData = (agencyId: string) => {
   try {
-    const { prisonerContentHubURL, selfServiceURL, disableSectionEventsAndProfile } = config.establishments.find(
-      establishment => establishment.agencyId === agencyId,
-    )
+    const { prisonerContentHubURL, selfServiceURL, hideHomepageEventsSummaryAndProfileLinkTile } =
+      config.establishments.find(establishment => establishment.agencyId === agencyId)
 
-    return { prisonerContentHubURL, selfServiceURL, disableSectionEventsAndProfile }
+    return { prisonerContentHubURL, selfServiceURL, hideHomepageEventsSummaryAndProfileLinkTile }
   } catch (err) {
     return null
   }

--- a/server/views/pages/homepage.njk
+++ b/server/views/pages/homepage.njk
@@ -4,7 +4,7 @@
 {% from "components/tiles-panel/index.njk" import tilesPanel %}
 
 {% set pageTitle = applicationName + " - Home" %}
-{% set disableSectionEventsAndProfile = establishmentLinksData.disableSectionEventsAndProfile %}
+{% set hideHomepageEventsSummaryAndProfileLinkTile = establishmentLinksData.hideHomepageEventsSummaryAndProfileLinkTile %}
 {% set mainClasses = "govuk-body govuk-!-margin-bottom-0 govuk-!-padding-bottom-0" %}
 
 {% block content %}
@@ -15,7 +15,7 @@
       <time class="govuk-heading-l">{{ today }}</time>
     </section>
 
-    {% if not disableSectionEventsAndProfile %}
+    {% if not hideHomepageEventsSummaryAndProfileLinkTile %}
     <section class="govuk-grid-row govuk-width-container" id="top-row-wrapper">
       <div id="events-summary-wrapper">
         {{ eventsSummary(eventsData, linksData.prisonerContentHubURL, user) }}

--- a/server/views/pages/homepage.njk
+++ b/server/views/pages/homepage.njk
@@ -4,6 +4,7 @@
 {% from "components/tiles-panel/index.njk" import tilesPanel %}
 
 {% set pageTitle = applicationName + " - Home" %}
+{% set disableSectionEventsAndProfile = establishmentLinksData.disableSectionEventsAndProfile %}
 {% set mainClasses = "govuk-body govuk-!-margin-bottom-0 govuk-!-padding-bottom-0" %}
 
 {% block content %}
@@ -14,6 +15,7 @@
       <time class="govuk-heading-l">{{ today }}</time>
     </section>
 
+    {% if not disableSectionEventsAndProfile %}
     <section class="govuk-grid-row govuk-width-container" id="top-row-wrapper">
       <div id="events-summary-wrapper">
         {{ eventsSummary(eventsData, linksData.prisonerContentHubURL, user) }}
@@ -26,6 +28,7 @@
         </a>
       </div>
     </section>
+    {% endif %}
 
     <div class="container-background-black tiles-panel" data-test="tiles-panel">
       {{ tilesPanel(linksData, user) }}

--- a/server/views/pages/homepage.njk
+++ b/server/views/pages/homepage.njk
@@ -4,7 +4,7 @@
 {% from "components/tiles-panel/index.njk" import tilesPanel %}
 
 {% set pageTitle = applicationName + " - Home" %}
-{% set hideHomepageEventsSummaryAndProfileLinkTile = establishmentLinksData.hideHomepageEventsSummaryAndProfileLinkTile %}
+{% set hideHomepageEventsSummaryAndProfileLinkTile = hideHomepageEventsSummaryAndProfileLinkTile %}
 {% set mainClasses = "govuk-body govuk-!-margin-bottom-0 govuk-!-padding-bottom-0" %}
 
 {% block content %}


### PR DESCRIPTION
[LNP-494](https://dsdmoj.atlassian.net/browse/LNP-494)

Added a '_hideHomepageEventsSummaryAndProfileLinkTile_' flag to the establishments config, setting it to _true_ for one specific establishment (berwyn) where the home page events summary and profile tile should be hidden. For all other establishments, this flag is omitted, meaning the homepage events summary and profile link tile link will be shown by default. 

[LNP-494]: https://dsdmoj.atlassian.net/browse/LNP-494?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ