### PR TITLE
Fix refresh token issue

### DIFF
--- a/server/authentication/refreshToken.ts
+++ b/server/authentication/refreshToken.ts
@@ -23,7 +23,6 @@ export const millisecondsPlusMinutesInSeconds = (now: number, minutes: number): 
 }
 
 export const tokenHasNotExpired = (token: IdToken | RefreshToken, nowEpochPlusMinutes: number): boolean => {
-  logger.info(`Check if token has not expired given exp is ${token.exp} and current time is ${nowEpochPlusMinutes}`)
   return token.exp >= nowEpochPlusMinutes
 }
 
@@ -81,6 +80,7 @@ export const checkTokenValidityAndUpdate = async (req: Request, res: Response, n
     )
   ) {
     try {
+      logger.info(`Refresh token`)
       const updatedTokensResponse: UpdatedTokensResponse = await getUpdatedToken(refreshToken)
 
       // updates req.user for the current request

--- a/server/middleware/setUpAuthentication.ts
+++ b/server/middleware/setUpAuthentication.ts
@@ -37,10 +37,11 @@ export default function setUpAuth(): Router {
       try {
         logger.debug(`Current cookie expiry is ${new Date(req.session.cookie.expires)}`)
         const parsedRefreshToken = JSON.parse(Buffer.from(req.user.refreshToken?.split('.')[1], 'base64').toString())
-        const cookieExpiresTime = new Date(parsedRefreshToken.exp * 1000)
+        const oneSecondInMillis = 1000
+        const refreshTokenExpInMillis = parsedRefreshToken.exp * oneSecondInMillis
 
-        req.session.cookie.expires = cookieExpiresTime
-        logger.debug(`Updated cookie expiry to ${cookieExpiresTime}`)
+        req.session.cookie.maxAge = refreshTokenExpInMillis - Date.now()
+        logger.debug(`Updated cookie expiry to ${new Date(req.session.cookie.expires)}`)
       } catch (e) {
         logger.error('Failed to parse refresh token')
       }

--- a/server/middleware/setUpWebSession.ts
+++ b/server/middleware/setUpWebSession.ts
@@ -18,7 +18,7 @@ export default function setUpWebSession(): Router {
       secret: config.session.secret,
       resave: false, // redis implements touch so shouldn't need this
       saveUninitialized: false,
-      rolling: true,
+      rolling: false,
     }),
   )
 


### PR DESCRIPTION
- Prevent rolling session that caused session to reset.
- Use cookie maxAge in-place of cookie expires.