### PR TITLE
LNP-494-adjusting-min-height-in-landscape-view-for-hidden-tiles-homepage

### DIFF
--- a/assets/scss/local.scss
+++ b/assets/scss/local.scss
@@ -2,6 +2,12 @@
   min-height: 600px;
 }
 
+@media only screen and (orientation: landscape) {
+  .govuk-main-wrapper.hidden-tiles {
+    min-height: 0 !important;
+  }
+}
+
 .container-background-black {
   background-color: govuk-colour('black');
 }

--- a/server/views/pages/homepage.njk
+++ b/server/views/pages/homepage.njk
@@ -6,6 +6,9 @@
 {% set pageTitle = title + " - " + applicationName %}
 {% set hideHomepageEventsSummaryAndProfileLinkTile = hideHomepageEventsSummaryAndProfileLinkTile %}
 {% set mainClasses = "govuk-body govuk-!-margin-bottom-0 govuk-!-padding-bottom-0" %}
+{% if hideHomepageEventsSummaryAndProfileLinkTile %}
+    {% set mainClasses = mainClasses + " hidden-tiles" %}
+{% endif %}    
 
 {% block content %}
 


### PR DESCRIPTION

[LNP-494](https://dsdmoj.atlassian.net/browse/LNP-494)

- Added conditional logic to append the _hidden-tiles_ class to the mainClasses if hideHomepageEventsSummaryAndProfileLinkTile is true.

- Added a media query to set min-height to 0 in landscape orientation when the hidden-titles class is applied

[LNP-494]: https://dsdmoj.atlassian.net/browse/LNP-494?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ