### PR TITLE
update-micromatch-non-vulnerable-version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8558,9 +8558,9 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
-      "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "dependencies": {
         "braces": "^3.0.3",


### PR DESCRIPTION
[LNP-972](https://dsdmoj.atlassian.net/browse/LNP-972)
Updated micromatch to 4.0.8, non-vulnerbale version.
https://github.com/micromatch/micromatch/releases/tag/4.0.8

[LNP-972]: https://dsdmoj.atlassian.net/browse/LNP-972?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ