### PR TITLE
README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ Or run tests with the cypress UI:
 
 `npm run int-test-ui`
 
-
 ### Dependency Checks
 
 The template project has implemented some scheduled checks to ensure that key dependencies are kept up to date.


### PR DESCRIPTION
PR with no code changes - attempting to figure out why the `deploy_staging_preview` task is failing.

I can see this event when circleci is attempting to deploy the build:

```
kubectl events -n hmpps-launchpad-staging

...

Error creating: pods "hmpps-launchpad-home-ui-dc98fb6b5-" is forbidden: error looking up service account hmpps-launchpad-staging/hmpps-launchpad-home-ui: serviceaccount "hmpps-launchpad-home-ui" not found
```

And I can see that the deployment has a Service Account in its definition:

```
kubectl describe deployment hmpps-launchpad-home-ui -n hmpps-launchpad-staging

...

Pod Template:
  Labels:           app=hmpps-launchpad-home-ui
                    release=hmpps-launchpad-home-ui
  Service Account:  hmpps-launchpad-home-ui
```

However this shouldn't be there at all. There's no service account defined in the helm charts. I think this was picked up from an earlier deployment when it was defined in helm, and although it was taken out of the helm charts it still exists in kubernetes.

How do we take it out of kubernetes config so the deployment will succeed again?

