### PR TITLE
LNP-1184: Updated auditing for external links

### DIFF
--- a/server/constants/audit.ts
+++ b/server/constants/audit.ts
@@ -1,5 +1,6 @@
 export const enum AUDIT_ACTIONS {
   VIEW_PAGE = 'VIEW_PAGE',
+  VIEW_EXTERNAL_PAGE = 'VIEW_EXTERNAL_PAGE',
 }
 
 export const enum AUDIT_PAGE_NAMES {

--- a/server/routes/adjudications/index.ts
+++ b/server/routes/adjudications/index.ts
@@ -10,7 +10,6 @@ import type { Services } from '../../services'
 
 import { formatAdjudication } from '../../utils/adjudications/formatAdjudication'
 import { getPaginationData } from '../../utils/pagination/pagination'
-import { getEstablishmentData } from '../../utils/utils'
 import auditPageViewMiddleware from '../../middleware/auditPageViewMiddleware'
 import { AUDIT_PAGE_NAMES } from '../../constants/audit'
 
@@ -25,7 +24,6 @@ export default function routes(services: Services): Router {
       const { user } = res.locals
       const language = req.language || i18next.language
 
-      const { prisonerContentHubURL } = getEstablishmentData(user.idToken.establishment.agency_id) || {}
       const reportedAdjudications = await services.adjudicationsService.getReportedAdjudicationsFor(
         user.idToken.booking.id,
         user.idToken.establishment.agency_id,
@@ -42,7 +40,7 @@ export default function routes(services: Services): Router {
           paginationData,
           rawQuery: req.query.page,
           reportedAdjudications: pagedReportedAdjudications,
-          readMoreUrl: `${prisonerContentHubURL}/content/4193`,
+          readMoreUrl: '/external/adjudications',
         },
         errors: req.flash('errors'),
         message: req.flash('message'),
@@ -57,7 +55,6 @@ export default function routes(services: Services): Router {
     asyncHandler(async (req: Request, res: Response) => {
       const { user } = res.locals
 
-      const { prisonerContentHubURL } = getEstablishmentData(user.idToken.establishment.agency_id) || {}
       const { reportedAdjudication } = await services.adjudicationsService.getReportedAdjudication(
         req.params.chargeNumber,
         user.idToken.establishment?.agency_id,
@@ -75,7 +72,7 @@ export default function routes(services: Services): Router {
             data: {
               adjudication: formattedAdjudication,
               chargeNumber: req.params.chargeNumber,
-              readMoreUrl: `${prisonerContentHubURL}/content/4193`,
+              readMoreUrl: '/external/adjudications',
             },
           })
     }),

--- a/server/routes/external/index.ts
+++ b/server/routes/external/index.ts
@@ -1,32 +1,59 @@
 import { Request, Response, Router } from 'express'
+import { auditService } from '@ministryofjustice/hmpps-audit-client'
 import { asyncHandler } from '../../middleware/asyncHandler'
-import auditPageViewMiddleware from '../../middleware/auditPageViewMiddleware'
-import { AUDIT_PAGE_NAMES } from '../../constants/audit'
 import logger from '../../../logger'
 import { getEstablishmentData } from '../../utils/utils'
+import { AUDIT_ACTIONS } from '../../constants/audit'
+import config from '../../config'
 
 export default function routes(): Router {
   const router = Router()
 
   router.get(
-    '/:target(self\\-service|content\\-hub|prison\\-radio|inside\\-time)',
-    auditPageViewMiddleware(AUDIT_PAGE_NAMES.EXTERNAL),
+    '/:target(self\\-service|content\\-hub|prison\\-radio|inside\\-time|adjudications|incentives|timetable|transactions|visits|privacy-policy|transactions-help)',
     asyncHandler(async (req: Request, res: Response) => {
-      const { user } = res.locals
       const { target } = req.params
+      const { idToken } = res.locals.user
+      const agencyId = idToken.establishment?.agency_id
+      const bookingId = idToken.booking.id
+      const prisonerId = idToken.sub
 
-      const { prisonerContentHubURL, selfServiceURL } = getEstablishmentData(user.idToken.establishment.agency_id)
+      const { prisonerContentHubURL, selfServiceURL } = getEstablishmentData(agencyId)
 
       const links: { [key: string]: string } = {
         'self-service': selfServiceURL,
         'content-hub': prisonerContentHubURL,
         'prison-radio': `${prisonerContentHubURL}/tags/785`,
         'inside-time': 'https://insidetimeprison.org/',
+        adjudications: `${prisonerContentHubURL}/content/4193`,
+        incentives: `${prisonerContentHubURL}/tags/1417`,
+        timetable: `${prisonerContentHubURL}/tags/1341`,
+        transactions: `${prisonerContentHubURL}/tags/872`,
+        visits: `${prisonerContentHubURL}/tags/1133`,
+        'privacy-policy': `${prisonerContentHubURL}/content/4856`,
+        'transactions-help': `${prisonerContentHubURL}/content/8534`,
       }
 
       const redirectUrl = links[target]
 
-      logger.info(`Redirecting ${user.idToken.sub} to ${redirectUrl}`)
+      logger.info(`Redirecting ${prisonerId} to ${redirectUrl}`)
+
+      await auditService.sendAuditMessage({
+        action: AUDIT_ACTIONS.VIEW_EXTERNAL_PAGE,
+        who: prisonerId,
+        service: config.apis.audit.serviceName,
+        details: JSON.stringify({
+          page: target.toUpperCase().replace('-', '_'),
+          method: req.method,
+          pageUrl: req.originalUrl,
+          params: req.params,
+          query: req.query,
+          body: req.body,
+          agencyId,
+          bookingId,
+          redirectUrl,
+        }),
+      })
 
       res.redirect(redirectUrl)
     }),

--- a/server/routes/profile/index.ts
+++ b/server/routes/profile/index.ts
@@ -10,7 +10,6 @@ import type { Services } from '../../services'
 
 import { isFeatureEnabled } from '../../utils/featureFlag/featureFlagUtils'
 import { formatBalances } from '../../utils/transactions/formatBalances'
-import { getEstablishmentData } from '../../utils/utils'
 import auditPageViewMiddleware from '../../middleware/auditPageViewMiddleware'
 import { AUDIT_PAGE_NAMES } from '../../constants/audit'
 
@@ -35,7 +34,6 @@ export default function routes(services: Services): Router {
         ),
       ])
 
-      const { prisonerContentHubURL } = getEstablishmentData(establishment.agency_id)
       const { hasAdjudications } = await services.adjudicationsService.hasAdjudications(
         booking.id,
         establishment.agency_id,
@@ -80,28 +78,28 @@ export default function routes(services: Services): Router {
         data: {
           adjudications: {
             hasAdjudications,
-            readMoreUrl: `${prisonerContentHubURL}/content/4193`,
+            readMoreUrl: '/external/adjudications',
             isEnabled: isAdjudicationsEnabled,
           },
           incentives: {
             incentivesData,
-            readMoreUrl: `${prisonerContentHubURL}/tags/1417`,
+            readMoreUrl: '/external/incentives',
           },
           socialVisitors: {
             isEnabled: isSocialVisitorsEnabled,
           },
           timetable: {
             timetableEvents: timetableEvents[0],
-            readMoreUrl: `${prisonerContentHubURL}/tags/1341`,
+            readMoreUrl: '/external/timetable',
           },
           transactions: {
             balances: formatBalances(transactionsBalances),
-            readMoreUrl: `${prisonerContentHubURL}/tags/872`,
+            readMoreUrl: '/external/transactions',
             isEnabled: isTransactionsEnabled,
           },
           visits: {
             nextVisit: nextVisitData,
-            readMoreUrl: `${prisonerContentHubURL}/tags/1133`,
+            readMoreUrl: '/external/visits',
             visitsRemaining,
             isEnabled: isVisitsEnabled,
           },

--- a/server/routes/transactions/index.ts
+++ b/server/routes/transactions/index.ts
@@ -65,7 +65,6 @@ export default function routes(services: Services): Router {
       data: {
         accountTypes: AccountTypes,
         balance: getBalanceByAccountCode(balances, accountCode),
-        contentHubTransactionsHelpLinkUrl: `/content/8534`,
         dateSelectionRange,
         hasDamageObligations: balances.damageObligations > 0,
         selectedDate,
@@ -106,7 +105,6 @@ export default function routes(services: Services): Router {
       data: {
         accountTypes: AccountTypes,
         balance: balances.damageObligations,
-        contentHubTransactionsHelpLinkUrl: `/content/8534`,
         damageObligations: createDamageObligationsTable(damageObligationsWithPrison, language),
         selectedTab: TransactionTypes.DAMAGE_OBLIGATIONS,
       },

--- a/server/routes/visits/index.ts
+++ b/server/routes/visits/index.ts
@@ -8,7 +8,6 @@ import featureFlagMiddleware from '../../middleware/featureFlag/featureFlag'
 import type { Services } from '../../services'
 
 import { getPaginationData } from '../../utils/pagination/pagination'
-import { getEstablishmentData } from '../../utils/utils'
 import auditPageViewMiddleware from '../../middleware/auditPageViewMiddleware'
 import { AUDIT_PAGE_NAMES } from '../../constants/audit'
 
@@ -20,7 +19,6 @@ export default function routes(services: Services): Router {
     featureFlagMiddleware(Features.SocialVisitors),
     auditPageViewMiddleware(AUDIT_PAGE_NAMES.VISITS),
     asyncHandler(async (req: Request, res: Response) => {
-      const { prisonerContentHubURL } = getEstablishmentData(req.user.idToken.establishment.agency_id) || {}
       const socialVisitorsRes = await services.prisonerContactRegistryService.getSocialVisitors(
         req.user.idToken.sub,
         req.user.idToken.establishment.agency_id,
@@ -35,7 +33,7 @@ export default function routes(services: Services): Router {
         data: {
           paginationData,
           rawQuery: req.query.page,
-          readMoreUrl: `${prisonerContentHubURL}/tags/1133`,
+          readMoreUrl: '/external/visits',
           socialVisitors,
         },
         errors: req.flash('errors'),

--- a/server/views/components/footer/template.njk
+++ b/server/views/components/footer/template.njk
@@ -5,7 +5,7 @@
         <h2 class="govuk-visually-hidden">Links</h2>
         <ul class="govuk-footer__inline-list">
           <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" rel="noreferrer noopener" target="_blank" href="{{prisonerContentHubUrl}}/content/4856">
+            <a class="govuk-footer__link" rel="noreferrer noopener" target="_blank" href="/external/privacy-policy">
               Privacy policy
             </a>
           </li>

--- a/server/views/components/transactions/help.njk
+++ b/server/views/components/transactions/help.njk
@@ -1,4 +1,4 @@
-{% macro transactionsHelp(prisonerContentHubUrl, contentHubTransactionsHelpLinkUrl, t) %}
+{% macro transactionsHelp(t) %}
   <details class="govuk-details" data-module="govuk-details">
     <summary class="govuk-details__summary">
       <span class="govuk-details__summary-text">{{ t('transactions.help') }}</span>
@@ -8,17 +8,17 @@
       <p class="govuk-body">{{ t('transactions.helpOptions.forMoreHelp') }}</p>
       <ul class="govuk-list govuk-list--bullet">
         <li>
-          <a 
-            href="{{ prisonerContentHubUrl }}{{ contentHubTransactionsHelpLinkUrl }}" 
-            class="govuk-link" 
-            rel="noreferrer noopener" 
+          <a
+            href="/external/transactions-help"
+            class="govuk-link"
+            rel="noreferrer noopener"
             target="_blank">
             {{ t('transactions.helpOptions.readMore') }}
           </a>
         </li>
         <li>{{ t('transactions.helpOptions.application') }}</li>
         <li>{{ t('transactions.helpOptions.askStaff') }}</li>
-      </ul> 
+      </ul>
     </div>
   </details>
 {% endmacro %}

--- a/server/views/pages/transactions.njk
+++ b/server/views/pages/transactions.njk
@@ -22,7 +22,7 @@
 
 {% block content %}
   <div class="govuk-body govuk-width-container govuk-frontend-supported">
-    {{ transactionsHelp(prisonerContentHubUrl, data.contentHubTransactionsHelpLinkUrl, t) }}
+    {{ transactionsHelp(t) }}
     {{ transactionsTabs(data.selectedTab, data.accountTypes, data.hasDamageObligations, t) }}
     {{ transactionsTable(data.balance, data.dateSelectionRange, data.selectedDate, data.transactions, t) }}
   </div>

--- a/server/views/pages/transactions/damage-obligations.njk
+++ b/server/views/pages/transactions/damage-obligations.njk
@@ -22,7 +22,7 @@
 
 {% block content %}
   <div class="govuk-body govuk-width-container govuk-frontend-supported">
-    {{ transactionsHelp(prisonerContentHubUrl, data.contentHubTransactionsHelpLinkUrl, t) }}
+    {{ transactionsHelp(t) }}
     {{ transactionsTabs(data.selectedTab, data.accountTypes, data.hasDamageObligations, t) }}
     {{ damageObligationsTable(data.balance, data.damageObligations, t)}}
   </div>


### PR DESCRIPTION
Now auditing several more links across a few more pages.

External links are now audited slightly different from internal pages:

`VIEW_PAGE` = an internal page
`VIEW_EXTERNAL_PAGE` = a link off an an external site. includes `redirectUrl` in the audit