### PR TITLE
LNP-1226: Updated log formatting to protect from CWE 117

### DIFF
--- a/server/data/api/prisonApi/client.ts
+++ b/server/data/api/prisonApi/client.ts
@@ -196,13 +196,17 @@ export default class PrisonApiClient {
         agencyId,
       )
     } catch (error) {
-      logger.error({
-        ...formatLogMessage('Error fetching transactions for prisoner', prisonerId, agencyId),
-        accountCode,
-        fromDate,
-        toDate,
-        error,
-      })
+      logger.error(
+        JSON.stringify({
+          logText: 'Error fetching transactions for prisoner',
+          prisonerId,
+          agencyId,
+          accountCode,
+          fromDate,
+          toDate,
+          error,
+        }),
+      )
       throw new Error('Failed to fetch transactions')
     }
   }

--- a/server/data/tokenVerification.ts
+++ b/server/data/tokenVerification.ts
@@ -11,7 +11,7 @@ function getApiClientToken(token: string) {
     .timeout(config.apis.tokenVerification.timeout)
     .then(response => Boolean(response.body && response.body.active))
     .catch(error => {
-      logger.error(getSanitisedError(error), 'Error calling tokenVerificationApi')
+      logger.error(JSON.stringify(getSanitisedError(error)), 'Error calling tokenVerificationApi')
     })
 }
 

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -77,5 +77,9 @@ export const convertLocation = (
 }
 
 export const formatLogMessage = (logText: string, prisonerId?: string, agencyId?: string) => {
-  return { logText, prisonerId, agencyId }
+  return JSON.stringify({
+    logText,
+    prisonerId,
+    agencyId,
+  })
 }


### PR DESCRIPTION
Quite heavy handed approach which loses all the rich formatting from bunyan, but it should protect from CWE 117 according to VERACODE Docs: https://docs.veracode.com/r/Supported_JavaScript_Cleansing_Functions