### PR TITLE
LNP-1259: Validate page number and selected date query params

### DIFF
--- a/server/routes/adjudications/index.test.ts
+++ b/server/routes/adjudications/index.test.ts
@@ -52,18 +52,18 @@ const mockServices = {
   adjudicationsService,
 }
 
-describe('GET /adjudications', () => {
-  beforeEach(() => {
-    jest.clearAllMocks()
+beforeEach(() => {
+  jest.clearAllMocks()
 
-    auditServiceSpy.mockResolvedValue()
-    app = appWithAllRoutes({
-      services: { adjudicationsService },
-      userSupplier: () => user,
-    })
+  auditServiceSpy.mockResolvedValue()
+  app = appWithAllRoutes({
+    services: { adjudicationsService },
+    userSupplier: () => user,
   })
+})
 
-  it('should render the /adjudications view', async () => {
+describe('GET /adjudications', () => {
+  it('should render the view', async () => {
     mockServices.adjudicationsService.getReportedAdjudicationsFor.mockResolvedValue({
       content: [reportedAdjudication],
     })
@@ -79,7 +79,7 @@ describe('GET /adjudications', () => {
     )
   })
 
-  it('should audit the /adjudications view', async () => {
+  it('should audit successful requests', async () => {
     mockServices.adjudicationsService.getReportedAdjudicationsFor.mockResolvedValue({
       content: [reportedAdjudication],
     })
@@ -95,7 +95,7 @@ describe('GET /adjudications', () => {
     )
   })
 
-  it('should audit the /adjudications pagination', async () => {
+  it('should audit the page number parameter if present', async () => {
     mockServices.adjudicationsService.getReportedAdjudicationsFor.mockResolvedValue({
       content: [reportedAdjudication],
     })
@@ -106,74 +106,81 @@ describe('GET /adjudications', () => {
     expect(auditServiceSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         what: AUDIT_EVENTS.VIEW_ADJUDICATIONS,
-        details: { page: '2' },
+        details: { page: 2 },
       }),
     )
   })
 
-  describe('the /adjudications/:chargeNumber route', () => {
-    it('should render the view', async () => {
-      mockServices.adjudicationsService.getReportedAdjudication.mockResolvedValue({ reportedAdjudication })
+  it('should redirect to /adjudications if the page number is invalid', async () => {
+    const result = await request(app).get('/adjudications?page=-2')
 
-      const res = await request(app).get('/adjudications/12345')
+    expect(result.status).toBe(302)
+    expect(result.headers.location).toBe('/adjudications')
+    expect(mockServices.adjudicationsService.getReportedAdjudicationsFor).not.toHaveBeenCalled()
+    expect(auditServiceSpy).not.toHaveBeenCalled()
+  })
+})
 
-      expect(res.status).toBe(200)
-      expect(mockServices.adjudicationsService.getReportedAdjudication).toHaveBeenCalledWith('12345', 'CKI', 'G1234UE')
+describe('GET /adjudications/:chargeNumber', () => {
+  it('should render the view', async () => {
+    mockServices.adjudicationsService.getReportedAdjudication.mockResolvedValue({ reportedAdjudication })
+
+    const res = await request(app).get('/adjudications/12345')
+
+    expect(res.status).toBe(200)
+    expect(mockServices.adjudicationsService.getReportedAdjudication).toHaveBeenCalledWith('12345', 'CKI', 'G1234UE')
+  })
+
+  it('should audit successful requests', async () => {
+    mockServices.adjudicationsService.getReportedAdjudication.mockResolvedValue({ reportedAdjudication })
+
+    await request(app).get('/adjudications/12345')
+
+    expect(auditServiceSpy).toHaveBeenCalledTimes(1)
+    expect(auditServiceSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        what: AUDIT_EVENTS.VIEW_CHARGE,
+        details: {
+          chargeNumber: '12345',
+        },
+      }),
+    )
+  })
+
+  it('should redirect to /adjudications if the charge does not exist', async () => {
+    mockServices.adjudicationsService.getReportedAdjudication.mockResolvedValue({ reportedAdjudication: null })
+
+    const res = await request(app).get('/adjudications/12345')
+
+    expect(res.status).toBe(302)
+    expect(res.headers.location).toBe('/adjudications')
+
+    expect(auditServiceSpy).not.toHaveBeenCalled()
+  })
+
+  it('should redirect to /adjudications if the charge does not belong to the user', async () => {
+    user.idToken.sub = 'incorrectId'
+    app = appWithAllRoutes({
+      services: { adjudicationsService },
+      userSupplier: () => user,
     })
+    mockServices.adjudicationsService.getReportedAdjudication.mockResolvedValue({ reportedAdjudication })
 
-    it('should audit successful requests', async () => {
-      mockServices.adjudicationsService.getReportedAdjudication.mockResolvedValue({ reportedAdjudication })
+    const res = await request(app).get('/adjudications/12345')
 
-      await request(app).get('/adjudications/12345')
+    expect(res.status).toBe(302)
+    expect(res.headers.location).toBe('/adjudications')
 
-      expect(auditServiceSpy).toHaveBeenCalledTimes(1)
-      expect(auditServiceSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          what: AUDIT_EVENTS.VIEW_CHARGE,
-          details: {
-            chargeNumber: '12345',
-          },
-        }),
-      )
-    })
+    expect(auditServiceSpy).not.toHaveBeenCalled()
+  })
 
-    it('should redirect to /adjudications if the charge does not exist', async () => {
-      mockServices.adjudicationsService.getReportedAdjudication.mockResolvedValue({ reportedAdjudication: null })
+  it('should redirect to /adjudications if the url contains any invalid characters', async () => {
+    const res = await request(app).get('/adjudications/123@45')
 
-      const res = await request(app).get('/adjudications/12345')
+    expect(res.status).toBe(302)
+    expect(res.headers.location).toBe('/adjudications')
 
-      expect(res.status).toBe(302)
-      expect(res.headers.location).toBe('/adjudications')
-
-      expect(auditServiceSpy).not.toHaveBeenCalled()
-    })
-
-    it('should redirect to /adjudications if the charge does not belong to the user', async () => {
-      user.idToken.sub = 'incorrectId'
-      app = appWithAllRoutes({
-        services: { adjudicationsService },
-        userSupplier: () => user,
-      })
-      mockServices.adjudicationsService.getReportedAdjudication.mockResolvedValue({ reportedAdjudication })
-
-      const res = await request(app).get('/adjudications/12345')
-
-      expect(res.status).toBe(302)
-      expect(res.headers.location).toBe('/adjudications')
-
-      expect(auditServiceSpy).not.toHaveBeenCalled()
-    })
-
-    it('should redirect to /adjudications if the url contains any invalid characters', async () => {
-      mockServices.adjudicationsService.getReportedAdjudication.mockResolvedValue({ reportedAdjudication })
-
-      const res = await request(app).get('/adjudications/123@45')
-
-      expect(res.status).toBe(302)
-      expect(res.headers.location).toBe('/adjudications')
-
-      expect(mockServices.adjudicationsService.getReportedAdjudicationsFor).not.toHaveBeenCalled()
-      expect(auditServiceSpy).not.toHaveBeenCalled()
-    })
+    expect(mockServices.adjudicationsService.getReportedAdjudicationsFor).not.toHaveBeenCalled()
+    expect(auditServiceSpy).not.toHaveBeenCalled()
   })
 })

--- a/server/routes/visits/index.test.ts
+++ b/server/routes/visits/index.test.ts
@@ -84,8 +84,17 @@ describe('GET /visits', () => {
     expect(auditServiceSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         what: AUDIT_EVENTS.VIEW_VISITS,
-        details: { page: '2' },
+        details: { page: 2 },
       }),
     )
+  })
+
+  it('should redirect to /visits if the page number is invalid', async () => {
+    const result = await request(app).get('/visits?page=0')
+
+    expect(result.status).toBe(302)
+    expect(result.headers.location).toBe('/visits')
+    expect(mockServices.prisonerContactRegistryService.getSocialVisitors).not.toHaveBeenCalled()
+    expect(auditServiceSpy).not.toHaveBeenCalled()
   })
 })

--- a/server/routes/visits/index.ts
+++ b/server/routes/visits/index.ts
@@ -1,4 +1,5 @@
 import { Request, Response, Router } from 'express'
+import * as z from 'zod'
 import { Features } from '../../constants/featureFlags'
 import featureFlagMiddleware from '../../middleware/featureFlag/featureFlag'
 import type { Services } from '../../services'
@@ -11,12 +12,22 @@ export default function routes(services: Services): Router {
   router.get('/', featureFlagMiddleware(Features.SocialVisitors), async (req: Request, res: Response) => {
     const { idToken } = req.user
 
+    const schema = z.object({
+      page: z.coerce.number().int().min(1).optional(),
+    })
+
+    const query = schema.safeParse(req.query)
+
+    if (!query.success) {
+      return res.redirect('/visits')
+    }
+
     const socialVisitorsRes = await services.prisonerContactRegistryService.getSocialVisitors(
       idToken.sub,
       idToken.establishment.agency_id,
     )
 
-    const paginationData = getPaginationData(Number(req.query.page), socialVisitorsRes.length)
+    const paginationData = getPaginationData(query.data.page, socialVisitorsRes.length)
     const socialVisitors = socialVisitorsRes
       .slice(paginationData.min - 1, paginationData.max)
       .map(visitor => [{ text: `${visitor.firstName} ${visitor.lastName}` }])
@@ -24,13 +35,13 @@ export default function routes(services: Services): Router {
     await auditService.audit({
       what: AUDIT_EVENTS.VIEW_VISITS,
       idToken,
-      details: { ...(req.query.page && { page: req.query.page }) },
+      details: { ...(query.data.page && { page: query.data.page }) },
     })
 
     return res.render('pages/visits', {
       data: {
         paginationData,
-        rawQuery: req.query.page,
+        rawQuery: query.data,
         readMoreUrl: '/external/visits',
         socialVisitors,
       },


### PR DESCRIPTION
Add validation in for query string parameters:
 * `?page=` (optional, integer, minimum 1)
 * `?selectedDate=` (optional, string, iso date format YYYY-MM-dd)

Redirect to the root url if the parameter is invalid.

Example: `/adjudications?page=xxx` -- redirects to --> `/adjudications`