### PR TITLE
LNP-1260: Security updates on settings and remove access pages

### DIFF
--- a/assets/js/all.js
+++ b/assets/js/all.js
@@ -30,20 +30,6 @@ function handleCardClick(event) {
   }
 }
 
-function initDeleteButtonHandler() {
-  const yesButton = document.getElementById('remove-access__button-yes')
-  const noButton = document.getElementById('remove-access__button-no')
-  const actionInput = document.getElementById('action-input')
-
-  if (yesButton) {
-    yesButton.addEventListener('click', () => (actionInput.value = 'remove'))
-  }
-
-  if (noButton) {
-    noButton.addEventListener('click', () => (actionInput.value = 'cancel'))
-  }
-}
-
 function initHeader() {
   const userToggle = document.querySelector('.launchpad-home-header__user-menu-toggle')
   const userMenu = document.getElementById('launchpad-home-header-user-menu')

--- a/server/routes/removeAccess/index.ts
+++ b/server/routes/removeAccess/index.ts
@@ -1,4 +1,6 @@
 import { Request, Response, Router } from 'express'
+import i18next from 'i18next'
+import * as z from 'zod'
 import { Features } from '../../constants/featureFlags'
 import featureFlagMiddleware from '../../middleware/featureFlag/featureFlag'
 import { Services } from '../../services'
@@ -8,34 +10,43 @@ export default function routes(services: Services): Router {
   const router = Router()
 
   router.get('/', featureFlagMiddleware(Features.Settings), async (req: Request, res: Response) => {
-    const { clientId, clientLogoUri, client } = req.query
     const { user } = res.locals
+
+    const schema = z.object({
+      clientId: z.uuid(),
+    })
+
+    const query = schema.safeParse(req.query)
+
+    if (!query.success) {
+      req.flash('errors', 'Invalid client ID')
+      return res.redirect('/settings')
+    }
 
     const approvedClients = await services.launchpadAuthService.getApprovedClients(
       user.idToken.sub,
       user.idToken.establishment.agency_id,
       user.accessToken,
     )
-    const validClient = approvedClients.content.find(c => c.id === clientId)
+    const validClient = approvedClients.content.find(c => c.id === query.data.clientId)
 
     if (!validClient) {
-      req.flash('errors', 'Invalid client ID.')
+      req.flash('errors', 'Invalid client ID')
       return res.redirect('/settings')
     }
 
     await auditService.audit({
       what: AUDIT_EVENTS.VIEW_REMOVE_APP_ACCESS,
       idToken: user.idToken,
-      details: { clientId, client },
+      details: { clientId: query.data.clientId },
     })
 
     return res.render('pages/remove-access', {
       data: {
         userId: user.idToken.sub,
-        clientId,
-        clientLogoUri,
-        client,
-        accessToken: user.accessToken,
+        clientId: query.data.clientId,
+        clientLogoUri: validClient.logoUri,
+        client: validClient.name,
       },
       csrfToken: req.csrfToken(),
       errors: req.flash('errors'),
@@ -44,40 +55,52 @@ export default function routes(services: Services): Router {
   })
 
   router.post('/', featureFlagMiddleware(Features.Settings), async (req: Request, res: Response) => {
-    const { userId, clientId, client, action } = req.body
     const { user } = res.locals
 
-    const approvedClients = await services.launchpadAuthService.getApprovedClients(
-      userId,
-      user.idToken.establishment.agency_id,
-      user.accessToken,
-    )
-    const validClient = approvedClients.content.find(c => c.id === clientId)
+    const schema = z.object({
+      clientId: z.uuid(),
+      action: z.enum(['remove', 'cancel']),
+    })
 
-    if (!validClient) {
-      req.flash('errors', 'Invalid client ID.')
+    const body = schema.safeParse(req.body)
+
+    if (!body.success) {
+      req.flash('errors', 'Invalid client ID')
       return res.redirect('/settings')
     }
 
-    if (action === 'remove') {
+    const approvedClients = await services.launchpadAuthService.getApprovedClients(
+      user.idToken.sub,
+      user.idToken.establishment.agency_id,
+      user.accessToken,
+    )
+    const validClient = approvedClients.content.find(c => c.id === body.data.clientId)
+
+    if (!validClient) {
+      req.flash('errors', 'Invalid client ID')
+      return res.redirect('/settings')
+    }
+
+    if (body.data.action === 'remove') {
       try {
+        const language = req.language || i18next.language
+
         await auditService.audit({
           what: AUDIT_EVENTS.DELETE_APP_ACCESS,
           idToken: user.idToken,
-          details: { clientId, client },
+          details: { clientId: body.data.clientId },
         })
 
         await services.launchpadAuthService.removeClientAccess(
-          clientId,
-          userId,
+          body.data.clientId,
+          user.idToken.sub,
           user.idToken.establishment.agency_id,
           user.accessToken,
         )
-        return res.redirect(`/settings?success=true&client=${client}`)
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      } catch (error) {
-        req.flash('errors', 'Failed to remove access.')
-        return res.redirect('/settings?success=false')
+
+        req.flash('message', `${i18next.t('settings.appAccess.removedAccess', { lng: language })} ${validClient.name}`)
+      } catch {
+        req.flash('errors', 'Failed to remove access')
       }
     }
 

--- a/server/routes/settings/index.test.ts
+++ b/server/routes/settings/index.test.ts
@@ -100,9 +100,18 @@ describe('GET /settings', () => {
       expect.objectContaining({
         what: AUDIT_EVENTS.VIEW_SETTINGS,
         details: {
-          page: '2',
+          page: 2,
         },
       }),
     )
+  })
+
+  it('should redirect to /settings if the page param is invalid', async () => {
+    const result = await request(app).get('/settings?page=two')
+
+    expect(result.status).toBe(302)
+    expect(result.headers.location).toBe('/settings')
+    expect(mockServices.launchpadAuthService.getApprovedClients).not.toHaveBeenCalled()
+    expect(auditServiceSpy).not.toHaveBeenCalled()
   })
 })

--- a/server/views/pages/remove-access.njk
+++ b/server/views/pages/remove-access.njk
@@ -5,8 +5,8 @@
   <div class="govuk-body remove-access__wrapper">
     <div class="remove-access__container">
       {% if data.clientLogoUri %}
-        <img 
-          src="{{ data.clientLogoUri }}" 
+        <img
+          src="{{ data.clientLogoUri }}"
           max-width="104px"
           alt="Client logo"
           loading="lazy">
@@ -14,15 +14,13 @@
 
       <div class="govuk-heading-m">{{ t('settings.removeAccessScreen.removeAccess') }}</div>
       <p class="govuk-!-margin-top-6">{{ t('settings.removeAccessScreen.confirmation') }} {{ data.client }}?</p>
-    
+
       <div class="remove-access__buttons">
         <form action="/remove-access" method="POST">
           <input type="hidden" name="_csrf" value="{{ csrfToken }}">
-          <input type="hidden" name="userId" value="{{ data.userId }}">
           <input type="hidden" name="clientId" value="{{ data.clientId }}">
-          <input type="hidden" name="client" value="{{ data.client }}">
-          <input type="hidden" id="action-input" name="action" value="remove">
-          
+          <input type="hidden" name="action" value="remove">
+
           {{ govukButton({
             text: t('settings.removeAccessScreen.yes'),
             id: "remove-access__button-yes",
@@ -30,6 +28,11 @@
               type: "submit"
             }
           }) }}
+        </form>
+        <form action="/remove-access" method="POST">
+          <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+          <input type="hidden" name="clientId" value="{{ data.clientId }}">
+          <input type="hidden" name="action" value="cancel">
 
           {{ govukButton({
             text: t('settings.removeAccessScreen.no'),

--- a/server/views/pages/settings.njk
+++ b/server/views/pages/settings.njk
@@ -10,19 +10,21 @@
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block beforeContent %}
-  {% if response.success == 'success' %}
+  {% if message | length %}
     <div class="govuk-width-container govuk-!-margin-top-6">
       {{ mojBanner({
         type: 'success',
-        text: t('settings.appAccess.removedAccess') + '' + response.client,
+        text: message,
         iconFallbackText: 'Success'
       }) }}
     </div>
-  {% elseif response.success == 'error' %}
+  {% endif %}
+
+  {% if errors | length %}
     <div class="govuk-width-container govuk-!-margin-top-6">
       {{ mojBanner({
         type: 'warning',
-        text: 'Error',
+        text: errors,
         iconFallbackText: 'Warning'
       }) }}
     </div>
@@ -43,7 +45,7 @@
   <div class="govuk-width-container govuk-frontend-supported govuk-!-margin-top-8">
     <table class="govuk-table">
       <caption class="govuk-table__caption govuk-table__caption--m">{{ t('settings.appAccess.access') }}</caption>
-      
+
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">
           <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">{{ t('settings.appAccess.app') }}</th>
@@ -55,18 +57,14 @@
 
       <tbody class="govuk-table__body">
         {% for client in data.approvedClients %}
-          {% set removeAccessUrl = "/remove-access?clientId=" + client.id + "&client=" + client.name %}
-          
-          {% if client.logoUri %}
-            {% set removeAccessUrl = removeAccessUrl + "&clientLogoUri=" + client.logoUri %}
-          {% endif %}
+          {% set removeAccessUrl = "/remove-access?clientId=" + client.id %}
 
           <tr class="govuk-table__row">
             <td class="govuk-table__cell govuk-table__cell--valign-middle govuk-!-margin-top-0 govuk-!-margin-bottom-0">
               <span class="two-column-cell govuk-!-margin-left-0">
                 {% if client.logoUri %}
-                  <img 
-                    src="{{ client.logoUri }}" 
+                  <img
+                    src="{{ client.logoUri }}"
                     max-width="104px"
                     alt="client logo"
                     loading="lazy">


### PR DESCRIPTION
* Removed input fields that we can infer (e.g. we don't need the client name if we have the client id)
* Added validation to remaining user inputs (e.g. page numbers, client ids)
* Updated settings page to show success and error messages via the flash mechanism (not user editable) rather than query params (user editable)
* Updated remove access form so it does not require javascript to function correctly