### PR TITLE
LNP-1214: Restrict i18next to only english and welsh

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -40,6 +40,7 @@ i18next
   .use(FilesystemBackend)
   .init({
     preload: ['en', 'cy'],
+    supportedLngs: ['en', 'cy'],
     fallbackLng: 'en',
     backend: {
       loadPath: path.join(__dirname, 'locales/{{lng}}.json'),


### PR DESCRIPTION
Without the restriction we will set the `i18next` cookie value to whatever is in the `?lng` parameter.

Now we only set the cookie to `en` or `cy` and will ignore any invalid values.

Documentation: https://www.i18next.com/overview/configuration-options#languages-namespaces-resources